### PR TITLE
Fix null child bug

### DIFF
--- a/dsl/symbol/src/main/scala/preact/dsl/symbol/package.scala
+++ b/dsl/symbol/src/main/scala/preact/dsl/symbol/package.scala
@@ -31,8 +31,7 @@ package object symbol extends EntryImplicits {
               acc
 
             case Entry.EmptyChild =>
-              // https://github.com/developit/preact/issues/540
-              (acc._1, acc._2 ++ null)
+              (acc._1, acc._2)
           }
         }
       val vnodeAttributes = if (attributes.isEmpty) null else attributes


### PR DESCRIPTION
The workaround related with preactjs #540 breaks the todomvc example. The bug has been fixed in preactjs 8 therefore this workaround can be removed.
